### PR TITLE
Change hashbang to /bin/bash in update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PROJECT_DIR=$(pwd)
 


### PR DESCRIPTION
Please change the hashbang at the top of the file to /bin/bash or '/usr/bin/env bash'. 
Otherwise this file will not run on many versions of Linux, which symlink /bin/sh to dash.
